### PR TITLE
Обновлено описание поля events[].type в эндпоинте по кандидатам

### DIFF
--- a/potok-api-v3.yaml
+++ b/potok-api-v3.yaml
@@ -10506,7 +10506,7 @@ components:
                 type: string
               type:
                 type: string
-                description: Тип события
+                description: 'Тип события (возможные типы событий - `Event::CoverLetter`, `Event::Response`, `Event::Comment`, `Event::System`)'
             required:
               - id
               - subject


### PR DESCRIPTION
Изменено описание поля events[].type в модели Applicant_response.
Было: "тип события"
Стало "Тип события (возможные типы событий - `Event::CoverLetter`, `Event::Response`, `Event::Comment`, `Event::System`)"